### PR TITLE
Add renderSpy component

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
 ## Table of contents
 
-* [🔧 Installation](./#-installation)
-* [🕹 Usage](./#🕹-usage)
+- [🔧 Installation](./#-installation)
+- [🕹 Usage](./#🕹-usage)
 
 ## 🔧 Installation
 
@@ -25,7 +25,7 @@ This library comes with a handful of useful functions. Below is an example of ho
 import React from 'react'
 import getDocumentFromComponent from '@helpscout/react-utils/dist/getDocumentFromComponent'
 
-class Napolean extends React.Component {
+class Napoleon extends React.Component {
   ...
   componentDidMount () {
     this.doc = getDocumentFromComponent(this)
@@ -36,4 +36,3 @@ class Napolean extends React.Component {
 ```
 
 Check out [**the documentation**](docs/) for more details.
-

--- a/docs/compose.md
+++ b/docs/compose.md
@@ -18,12 +18,12 @@ Apply functions to a React component. Abstracted from [recompose](https://github
 import React from 'react'
 import compose from '@helpscout/react-utils/dist/compose'
 
-class Napolean extends React.Component {...}
+class Napoleon extends React.Component {...}
 
-const enhancedNapolean = compose(
+const enhancedNapoleon = compose(
   nunchuckSkills,
   computerHackingSkills,
   bowHuntingSkills
-)(Napolean)
+)(Napoleon)
 ```
 

--- a/docs/getShallowDiffs.md
+++ b/docs/getShallowDiffs.md
@@ -19,7 +19,7 @@ Plucks out the diffs between two sets of Objects. Very handy in spotting the pro
 import React from 'react'
 import getShallowDiffs from '@helpscout/react-utils/dist/getShallowDiffs'
 
-class Napolean extends React.Component {
+class Napoleon extends React.Component {
   ...
   componentDidUpdate (prevProps) {
     console.log(getShallowDiffs(prevProps, this.props))

--- a/docs/getdocumentfromcomponent.md
+++ b/docs/getdocumentfromcomponent.md
@@ -18,7 +18,7 @@ Retrieves the `document` where the Component was mounted to.
 import React from 'react'
 import getDocumentFromComponent from '@helpscout/react-utils/dist/getDocumentFromComponent'
 
-class Napolean extends React.Component {
+class Napoleon extends React.Component {
   ...
   componentDidMount () {
     this.doc = getDocumentFromComponent(this)

--- a/docs/getwindowfromcomponent.md
+++ b/docs/getwindowfromcomponent.md
@@ -18,7 +18,7 @@ Retrieves the `window` where the Component was mounted to.
 import React from 'react'
 import getWindowFromComponent from '@helpscout/react-utils/dist/getWindowFromComponent'
 
-class Napolean extends React.Component {
+class Napoleon extends React.Component {
   ...
   componentDidMount () {
     this.win = getWindowFromComponent(this)

--- a/docs/reactspy.md
+++ b/docs/reactspy.md
@@ -38,7 +38,7 @@ Napoleon Mounted
 Napoleon Rendered
 Changes: ['votedForPedro']
 Previous: { votedForPedro: false }
-Next: { votedForPedro: false }
+Next: { votedForPedro: true }
 
 Napoleon Unmounted
 ```

--- a/docs/reactspy.md
+++ b/docs/reactspy.md
@@ -1,0 +1,44 @@
+# reactSpy(options)(WrappedComponent)
+
+Higher-order component that logs the mount/unmount/render cycles of a React component. Useful for debugging performance!
+
+Inspired by React's performance tools and [`react-performance`](https://github.com/amsul/react-performance).
+
+## Arguments
+
+| Argument           | Type        | Description              |
+| :----------------- | :---------- | :----------------------- |
+| `options`          | `Object`    | Options for ReactSpy.    |
+| `WrappedComponent` | `Component` | The component to spy on. |
+
+## Options
+
+| Argument | Type     | Description                        |
+| :------- | :------- | :--------------------------------- |
+| `id`     | `string` | A name to be used in console logs. |
+
+## Examples
+
+```jsx
+import React from 'react'
+import reactSpy from '@helpscout/react-utils/dist/reactSpy'
+
+class Napoleon extends React.Component {
+  ...
+}
+
+export const reactSpy()(Napoleon)
+```
+
+Potential logs:
+
+```
+Napoleon Mounted
+
+Napoleon Rendered
+Changes: ['votedForPedro']
+Previous: { votedForPedro: false }
+Next: { votedForPedro: false }
+
+Napoleon Unmounted
+```

--- a/docs/renderSpy.md
+++ b/docs/renderSpy.md
@@ -1,4 +1,4 @@
-# reactSpy(options)(WrappedComponent)
+# renderSpy(options)(WrappedComponent)
 
 Higher-order component that logs the mount/unmount/render cycles of a React component. Useful for debugging performance!
 
@@ -8,7 +8,7 @@ Inspired by React's performance tools and [`react-performance`](https://github.c
 
 | Argument           | Type        | Description              |
 | :----------------- | :---------- | :----------------------- |
-| `options`          | `Object`    | Options for ReactSpy.    |
+| `options`          | `Object`    | Options for renderSpy.    |
 | `WrappedComponent` | `Component` | The component to spy on. |
 
 ## Options
@@ -21,13 +21,13 @@ Inspired by React's performance tools and [`react-performance`](https://github.c
 
 ```jsx
 import React from 'react'
-import reactSpy from '@helpscout/react-utils/dist/reactSpy'
+import renderSpy from '@helpscout/react-utils/dist/renderSpy'
 
 class Napoleon extends React.Component {
   ...
 }
 
-export const reactSpy()(Napoleon)
+export const renderSpy()(Napoleon)
 ```
 
 Potential logs:

--- a/docs/wrapcomponentname.md
+++ b/docs/wrapcomponentname.md
@@ -18,11 +18,11 @@ Wraps the name of a React component.
 import React from 'react'
 import wrapComponentName from '@helpscout/react-utils/dist/wrapComponentName'
 
-class Napolean extends React.Component {
+class Napoleon extends React.Component {
   ...
 }
 
-wrapComponentName(Napolean, 'withSkills')
-// withSkills(Napolean)
+wrapComponentName(Napoleon, 'withSkills')
+// withSkills(Napoleon)
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/react-utils",
-  "version": "1.0.3-0",
+  "version": "1.0.3-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/react-utils",
-  "version": "1.0.2",
+  "version": "1.0.3-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/react-utils",
-  "version": "1.0.3-0",
+  "version": "1.0.3-1",
   "description": "Handy utilities for React",
   "main": "dist/index.js",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpscout/react-utils",
-  "version": "1.0.2",
+  "version": "1.0.3-0",
   "description": "Handy utilities for React",
   "main": "dist/index.js",
   "private": false,

--- a/src/__tests__/getValidProps.test.js
+++ b/src/__tests__/getValidProps.test.js
@@ -51,7 +51,7 @@ test('Can render React component with valid props', () => {
     return <div {...getValidProps(props)} id="UncleRico" />
   }
   const wrapper = mount(
-    <UncleRico id="Rico" throwSteak="atNapolean" distance="quarterMile" />
+    <UncleRico id="Rico" throwSteak="atNapoleon" distance="quarterMile" />
   )
 
   const el = wrapper.find('div')
@@ -68,7 +68,7 @@ test('Filters out non-default on(*) props', () => {
   const wrapper = mount(
     <UncleRico
       id="Rico"
-      onThrowSteak="atNapolean"
+      onThrowSteak="atNapoleon"
       distance="quarterMile"
       onChange={() => {}}
     />

--- a/src/__tests__/renderSpy.test.js
+++ b/src/__tests__/renderSpy.test.js
@@ -69,6 +69,19 @@ test('Logs on prop changes', () => {
   expect(console.log).toHaveBeenCalledWith('Next', { title: 'Dynamite' })
 })
 
+test('No logs if does not re-render', () => {
+  const Napoleon = () => <div />
+  Napoleon.displayName = 'Napoleon'
+  const NapoleonSpy = renderSpy()(Napoleon)
+
+  const wrapper = mount(<NapoleonSpy title="Dynamite" />)
+  wrapper.setProps({ title: 'Dynamite' })
+
+  expect(console.group).toHaveBeenCalledWith('Napoleon Mounted')
+  expect(console.group).not.toHaveBeenCalledWith('Napoleon Rendered')
+  expect(console.log).not.toHaveBeenCalled()
+})
+
 test('Logs a custom name, if provided', () => {
   const Napoleon = () => <div />
   Napoleon.displayName = 'Napoleon'

--- a/src/__tests__/renderSpy.test.js
+++ b/src/__tests__/renderSpy.test.js
@@ -1,0 +1,80 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import renderSpy from '../renderSpy'
+
+beforeEach(() => {
+  console.group = jest.fn()
+  console.groupEnd = jest.fn()
+  console.log = jest.fn()
+})
+
+afterEach(() => {
+  console.group.mockClear()
+  console.groupEnd.mockClear()
+  console.log.mockClear()
+})
+
+test('Creates a wrapped displayName', () => {
+  const Napoleon = () => <div />
+  Napoleon.displayName = 'Napoleon'
+  const NapoleonSpy = renderSpy()(Napoleon)
+
+  expect(NapoleonSpy.displayName).toContain('withRenderSpy(Napoleon)')
+})
+
+test('Renders WrappedComponent with props', () => {
+  const Napoleon = ({ title }) => <div className="Napoleon">{title}</div>
+  const NapoleonSpy = renderSpy()(Napoleon)
+
+  const wrapper = mount(<NapoleonSpy title="Dynamite" />)
+  const el = wrapper.find('div.Napoleon')
+
+  expect(el.length).toBeTruthy()
+  expect(el.text()).toContain('Dynamite')
+})
+
+test('Logs on mount', () => {
+  const Napoleon = () => <div />
+  Napoleon.displayName = 'Napoleon'
+  const NapoleonSpy = renderSpy()(Napoleon)
+
+  mount(<NapoleonSpy />)
+
+  expect(console.group).toHaveBeenCalledWith('Napoleon Mounted')
+})
+
+test('Logs on unmount', () => {
+  const Napoleon = () => <div />
+  Napoleon.displayName = 'Napoleon'
+  const NapoleonSpy = renderSpy()(Napoleon)
+
+  const wrapper = mount(<NapoleonSpy />)
+  wrapper.unmount()
+
+  expect(console.group).toHaveBeenCalledWith('Napoleon Mounted')
+  expect(console.group).toHaveBeenCalledWith('Napoleon Unmounted')
+})
+
+test('Logs on prop changes', () => {
+  const Napoleon = () => <div />
+  Napoleon.displayName = 'Napoleon'
+  const NapoleonSpy = renderSpy()(Napoleon)
+
+  const wrapper = mount(<NapoleonSpy title="Nope" />)
+  wrapper.setProps({ title: 'Dynamite' })
+
+  expect(console.group).toHaveBeenCalledWith('Napoleon Rendered')
+  expect(console.log).toHaveBeenCalledWith('Changes', ['title'])
+  expect(console.log).toHaveBeenCalledWith('Previous', { title: 'Nope' })
+  expect(console.log).toHaveBeenCalledWith('Next', { title: 'Dynamite' })
+})
+
+test('Logs a custom name, if provided', () => {
+  const Napoleon = () => <div />
+  Napoleon.displayName = 'Napoleon'
+  const NapoleonSpy = renderSpy({ id: 'VoteForPedro' })(Napoleon)
+
+  mount(<NapoleonSpy />)
+
+  expect(console.group).toHaveBeenCalledWith('VoteForPedro Mounted')
+})

--- a/src/getComponentName.js
+++ b/src/getComponentName.js
@@ -1,5 +1,5 @@
 // @flow
-import type {ReactComponent} from './typings/index'
+import type { ReactComponent } from './typings/index'
 import isReactComponent from './isReactComponent'
 
 /**

--- a/src/renderSpy.js
+++ b/src/renderSpy.js
@@ -1,0 +1,58 @@
+import React from 'react'
+import hoistNonReactStatics from './hoistNonReactStatics'
+import getShallowDiffs from './getShallowDiffs'
+import getComponentName from './getComponentName'
+import wrapComponentName from './wrapComponentName'
+
+const defaultOptions = {}
+
+function renderSpy(options = defaultOptions) {
+  return function(WrappedComponent) {
+    const { id } = options
+    const displayName = id || getComponentName(WrappedComponent)
+
+    class ReactRenderSpy extends React.Component {
+      componentDidMount() {
+        console.group(`${displayName} Mounted`)
+        console.groupEnd()
+      }
+
+      componentDidUpdate(prevProps) {
+        const changes = getShallowDiffs(prevProps, this.props)
+        const { diffs, previous, next } = changes
+
+        console.group(`${displayName} Rendered`)
+        /* istanbul ignore else */
+        if (diffs.length) {
+          console.log('Changes', diffs)
+          console.log('Previous', previous)
+          console.log('Next', next)
+        }
+        console.groupEnd()
+      }
+
+      componentWillUnmount() {
+        console.group(`${displayName} Unmounted`)
+        console.groupEnd()
+      }
+
+      render() {
+        return <WrappedComponent {...this.props} />
+      }
+    }
+
+    const EnhancedComponent = hoistNonReactStatics(
+      ReactRenderSpy,
+      WrappedComponent
+    )
+
+    EnhancedComponent.displayName = wrapComponentName(
+      WrappedComponent,
+      'withRenderSpy'
+    )
+
+    return EnhancedComponent
+  }
+}
+
+export default renderSpy

--- a/src/renderSpy.js
+++ b/src/renderSpy.js
@@ -21,13 +21,12 @@ function renderSpy(options = defaultOptions) {
         const changes = getShallowDiffs(prevProps, this.props)
         const { diffs, previous, next } = changes
 
+        if (!diffs.length) return
+
         console.group(`${displayName} Rendered`)
-        /* istanbul ignore else */
-        if (diffs.length) {
-          console.log('Changes', diffs)
-          console.log('Previous', previous)
-          console.log('Next', next)
-        }
+        console.log('Changes', diffs)
+        console.log('Previous', previous)
+        console.log('Next', next)
         console.groupEnd()
       }
 


### PR DESCRIPTION
## Add renderSpy component

![screen recording 2018-11-21 at 01 03 pm](https://user-images.githubusercontent.com/2322354/48860065-e00e3800-ed8d-11e8-87e3-d2ffc8e3903a.gif)


This update adds a new HOC utility called renderSpy, which reports on the
mount/unmount/render cycles of a React component - very handy for
debugging performance!

Inspired by React's performance tools and [`react-performance`](https://github.com/amsul/react-performance).

## Examples

```jsx
import React from 'react'
import renderSpy from '@helpscout/react-utils/dist/renderSpy'

class Napoleon extends React.Component {
  ...
}

export const renderSpy()(Napoleon)
```

Potential logs:

```
Napoleon Mounted

Napoleon Rendered
Changes: ['votedForPedro']
Previous: { votedForPedro: false }
Next: { votedForPedro: true }

Napoleon Unmounted
```

Note!! I decided to roll my own performance spy tool instead of using `ReactPerformance.measure` because I couldn't get that library to work with our projects :(. Not sure why!