### PR TITLE
Add withSafeSetState HOC

### DIFF
--- a/docs/withsafesetstate.md
+++ b/docs/withsafesetstate.md
@@ -1,0 +1,48 @@
+# withSafeSetState()(WrappedComponent)
+
+Enhances the WrappedComponent's `setState` method to only work if the Component is mounted.
+
+## Arguments
+
+| Argument           | Type              | Description        |
+| :----------------- | :---------------- | :----------------- |
+| `WrappedComponent` | `React.Component` | A React component. |
+
+## Returns
+
+`React.Component`: The enhanced React component.
+
+## Additional Methods
+
+### `isComponentMounted()`
+
+**Returns**: `boolean`
+
+The component is also provided with the method `.isComponentMounted()`.
+
+Note: This is different then React's native `.isMounted()` method, which they are [deprecating](https://reactjs.org/blog/2015/12/16/ismounted-antipattern.html).
+
+## Examples
+
+```jsx
+import React from 'react'
+import withSafeSetState from '@helpscout/react-utils/dist/withSafeSetState'
+
+class Napoleon extends React.Component {
+  ...
+  componentWillUnmount() {
+    setTimeout(() => {
+      console.log('Tina, eat!')
+      this.setState({
+        feedTina: true
+      })
+    }, 1000)
+  }
+  ...
+}
+
+const EnhancedNapolean = withSafeSetState()(Napoleon)
+
+// When EnhancedNapolean unmounts, the setState() method with feedTina will
+// not be called. No warnings or errors will be thrown.
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -4900,6 +4900,11 @@
       "integrity": "sha1-AxkcQyy27qFou3fzpV/9zLiXhRQ=",
       "dev": true
     },
+    "dash-get": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dash-get/-/dash-get-1.0.1.tgz",
+      "integrity": "sha512-XxVQ5FDVkfHyKrGBSXeRN9QmkqxUAgiOPXLgPDkGfmOd231OSGDfTEbMoH9DQEjGgse9HvMeg9IvQKcGaGC+iw=="
+    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -17444,7 +17449,7 @@
       "dependencies": {
         "estree-walker": {
           "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.2.1.tgz",
+          "resolved": "http://registry.npmjs.org/estree-walker/-/estree-walker-0.2.1.tgz",
           "integrity": "sha1-va/oCVOD2EFNXcLs9MkXO225QS4=",
           "dev": true
         },

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   ],
   "dependencies": {
     "create-react-context": "0.2.2",
+    "dash-get": "1.0.1",
     "hoist-non-react-statics": "3.0.1"
   }
 }

--- a/src/__tests__/getDocumentFromComponent.test.js
+++ b/src/__tests__/getDocumentFromComponent.test.js
@@ -26,6 +26,44 @@ test('Can retrieve the document from a React component (16)', () => {
   }
 
   expect(getDocumentFromComponent(mockComponent)).toBe(mockDocument)
+
+  const mockAltComponent = {
+    _reactInternalFiber: {
+      _debugOwner: {
+        return: {
+          stateNode: {
+            ownerDocument: mockDocument,
+          },
+        },
+      },
+    },
+  }
+
+  expect(getDocumentFromComponent(mockAltComponent)).toBe(mockDocument)
+
+  const mockAltDeepComponent = {
+    _reactInternalFiber: {
+      _debugOwner: {
+        _debugOwner: {
+          return: {
+            stateNode: {
+              ownerDocument: mockDocument,
+            },
+          },
+        },
+      },
+    },
+  }
+
+  expect(getDocumentFromComponent(mockAltDeepComponent)).toBe(mockDocument)
+
+  const mockNonsenseComponent = {
+    _reactInternalFiber: {
+      _reactInternalNope: true,
+    },
+  }
+
+  expect(getDocumentFromComponent(mockNonsenseComponent)).toBe(document)
 })
 
 test('Fallsback to window.document, if React document cannot be retrieved', () => {

--- a/src/__tests__/withSafeSetState.test.js
+++ b/src/__tests__/withSafeSetState.test.js
@@ -150,7 +150,16 @@ describe('withSafeSetState', () => {
   })
 
   test('Can internally check if a component is mounted', () => {
+    const spy = jest.fn()
     class Sample extends React.Component {
+      someSetStateMethod(callback) {
+        this.setState(
+          {
+            gogo: true,
+          },
+          callback
+        )
+      }
       render() {
         return null
       }
@@ -160,9 +169,14 @@ describe('withSafeSetState', () => {
     const Compo = wrapper.find('Sample').getNode()
 
     expect(Compo.isComponentMounted()).toBe(true)
+    Compo.someSetStateMethod(spy)
+    expect(spy).toHaveBeenCalledTimes(1)
 
     wrapper.unmount()
 
     expect(Compo.isComponentMounted()).toBe(false)
+
+    Compo.someSetStateMethod(spy)
+    expect(spy).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/__tests__/withSafeSetState.test.js
+++ b/src/__tests__/withSafeSetState.test.js
@@ -1,0 +1,168 @@
+import React from 'react'
+import withSafeSetState from '../withSafeSetState'
+import { mount } from 'enzyme'
+
+describe('withSafeSetState', () => {
+  test('Statics are hoisted', () => {
+    const spy = jest.fn()
+
+    class Sample extends React.Component {
+      static SomeStatic = true
+      componentDidMount() {
+        spy()
+      }
+
+      render() {
+        return null
+      }
+    }
+
+    const EnhancedSample = withSafeSetState()(Sample)
+
+    expect(EnhancedSample.SomeStatic).toBe(true)
+  })
+
+  test('componentDidMount still works as expected', () => {
+    const spy = jest.fn()
+
+    class Sample extends React.Component {
+      componentDidMount() {
+        spy()
+      }
+
+      render() {
+        return null
+      }
+    }
+
+    const EnhancedSample = withSafeSetState()(Sample)
+    const wrapper = mount(<EnhancedSample />)
+    wrapper.unmount()
+
+    expect(spy).toHaveBeenCalled()
+  })
+
+  test('componentWillUnmount still works as expected', () => {
+    const spy = jest.fn()
+
+    class Sample extends React.Component {
+      componentWillUnmount() {
+        spy()
+      }
+
+      render() {
+        return null
+      }
+    }
+    const EnhancedSample = withSafeSetState()(Sample)
+    const wrapper = mount(<EnhancedSample />)
+    wrapper.unmount()
+
+    expect(spy).toHaveBeenCalled()
+  })
+
+  test('setState still works as expected', () => {
+    class Sample extends React.Component {
+      state = {
+        active: false,
+      }
+
+      componentDidMount() {
+        this.setState({
+          active: true,
+        })
+      }
+
+      render() {
+        return null
+      }
+    }
+
+    const EnhancedSample = withSafeSetState()(Sample)
+    const wrapper = mount(<EnhancedSample />)
+    const Compo = wrapper.find('Sample').getNode()
+
+    expect(Compo.state.active).toBe(true)
+
+    Compo.setState({ active: false })
+    expect(Compo.state.active).toBe(false)
+  })
+
+  test('Can trigger setState from prop update', () => {
+    class Sample extends React.Component {
+      state = {
+        active: false,
+      }
+
+      componentDidUpdate() {
+        if (!this.state.active) {
+          this.setState({
+            active: true,
+          })
+        }
+      }
+
+      render() {
+        return null
+      }
+    }
+
+    const EnhancedSample = withSafeSetState()(Sample)
+    const wrapper = mount(<EnhancedSample />)
+    const Compo = wrapper.find('Sample').getNode()
+
+    expect(Compo.state.active).toBe(false)
+
+    wrapper.setProps({ update: true })
+
+    expect(Compo.state.active).toBe(true)
+  })
+
+  test('Cannot setState if unmounted', () => {
+    class Sample extends React.Component {
+      state = {
+        active: false,
+      }
+
+      componentDidMount() {
+        this.setState({
+          active: true,
+        })
+      }
+
+      componentWillUnmount() {
+        this.setState({
+          active: 'doesNotMatter',
+        })
+      }
+
+      render() {
+        return null
+      }
+    }
+    const EnhancedSample = withSafeSetState()(Sample)
+    const wrapper = mount(<EnhancedSample />)
+    const Compo = wrapper.find('Sample').getNode()
+
+    wrapper.unmount()
+
+    expect(Compo.state.active).toBe(true)
+  })
+
+  test('Can internally check if a component is mounted', () => {
+    class Sample extends React.Component {
+      render() {
+        return null
+      }
+    }
+    const EnhancedSample = withSafeSetState()(Sample)
+    const wrapper = mount(<EnhancedSample />)
+    const Compo = wrapper.find('Sample').getNode()
+
+    expect(Compo.isComponentMounted()).toBe(true)
+
+    wrapper.unmount()
+
+    expect(Compo.isComponentMounted()).toBe(false)
+  })
+})

--- a/src/getDocumentFromComponent.js
+++ b/src/getDocumentFromComponent.js
@@ -1,6 +1,7 @@
 // @flow
-import type {ReactComponent} from './typings/index'
+import type { ReactComponent } from './typings/index'
 import isReactComponent from './isReactComponent'
+import get from 'dash-get'
 
 /**
  * Retrieves the document where the React Component has been
@@ -14,19 +15,25 @@ function getDocumentFromComponent(Component: ReactComponent): Document {
 
   // React 16.x
   if (Component._reactInternalFiber) {
-    return (
-      Component._reactInternalFiber.return &&
-      Component._reactInternalFiber.return.stateNode &&
-      Component._reactInternalFiber.return.stateNode.ownerDocument
+    const levelOneCheck = get(
+      Component,
+      '_reactInternalFiber.return.stateNode.ownerDocument'
     )
+    const levelTwoCheck = get(
+      Component,
+      '_reactInternalFiber._debugOwner.return.stateNode.ownerDocument'
+    )
+    const levelThreeCheck = get(
+      Component,
+      '_reactInternalFiber._debugOwner._debugOwner.return.stateNode.ownerDocument'
+    )
+
+    return levelOneCheck || levelTwoCheck || levelThreeCheck || document
   }
   // React 15.x
   /* istanbul ignore else */
   if (Component._reactInternalInstance) {
-    return (
-      Component._reactInternalInstance._context &&
-      Component._reactInternalInstance._context.document
-    )
+    return get(Component, '_reactInternalInstance._context.document', document)
   }
   /* istanbul ignore next */
   return document

--- a/src/withSafeSetState.js
+++ b/src/withSafeSetState.js
@@ -17,20 +17,20 @@ function withSafeSetState() {
     WrappedComponent.prototype.componentDidMount = function(...args) {
       isMounted = true
       if (componentDidMount) {
-        componentDidMount.bind(this)(...args)
+        componentDidMount.apply(this, args)
       }
     }
 
     WrappedComponent.prototype.componentWillUnmount = function(...args) {
       isMounted = false
       if (componentWillUnmount) {
-        componentWillUnmount.bind(this)(...args)
+        componentWillUnmount.apply(this, args)
       }
     }
 
     WrappedComponent.prototype.setState = function(...args) {
       if (isMounted && setState) {
-        setState.bind(this)(...args)
+        setState.apply(this, args)
       }
     }
 

--- a/src/withSafeSetState.js
+++ b/src/withSafeSetState.js
@@ -1,0 +1,47 @@
+import React from 'react'
+import hoistNonReactStatic from './hoistNonReactStatics'
+
+/**
+ * Enhances a component to ensure that setState can only be called if the
+ * component is mounted.
+ */
+function withSafeSetState() {
+  return function enhanceWithSafeSetState(WrappedComponent) {
+    let isMounted = false
+    const {
+      componentDidMount,
+      componentWillUnmount,
+      setState,
+    } = WrappedComponent.prototype
+
+    WrappedComponent.prototype.componentDidMount = function(...args) {
+      isMounted = true
+      if (componentDidMount) {
+        componentDidMount.bind(this)(...args)
+      }
+    }
+
+    WrappedComponent.prototype.componentWillUnmount = function(...args) {
+      isMounted = false
+      if (componentWillUnmount) {
+        componentWillUnmount.bind(this)(...args)
+      }
+    }
+
+    WrappedComponent.prototype.setState = function(...args) {
+      if (isMounted && setState) {
+        setState.bind(this)(...args)
+      }
+    }
+
+    WrappedComponent.prototype.isComponentMounted = () => isMounted
+
+    const WithSafeSetState = props => {
+      return <WrappedComponent {...props} />
+    }
+
+    return hoistNonReactStatic(WithSafeSetState, WrappedComponent)
+  }
+}
+
+export default withSafeSetState


### PR DESCRIPTION
## Add withSafeSetState HOC

This update adds a new HOC function, `withSafeSetState`. It enhances the
provided Wrapped component to ensure that `setState` only works if the
component is mounted.

---

# withSafeSetState()(WrappedComponent)

Enhances the WrappedComponent's `setState` method to only work if the Component is mounted.

## Arguments

| Argument           | Type              | Description        |
| :----------------- | :---------------- | :----------------- |
| `WrappedComponent` | `React.Component` | A React component. |

## Returns

`React.Component`: The enhanced React component.

## Additional Methods

### `isComponentMounted()`

**Returns**: `boolean`

The component is also provided with the method `.isComponentMounted()`.

Note: This is different then React's native `.isMounted()` method, which they are [deprecating](https://reactjs.org/blog/2015/12/16/ismounted-antipattern.html).

## Examples

```jsx
import React from 'react'
import withSafeSetState from '@helpscout/react-utils/dist/withSafeSetState'

class Napoleon extends React.Component {
  ...
  componentWillUnmount() {
    setTimeout(() => {
      console.log('Tina, eat!')
      this.setState({
        feedTina: true
      })
    }, 1000)
  }
  ...
}

const EnhancedNapolean = withSafeSetState()(Napoleon)

// When EnhancedNapolean unmounts, the setState() method with feedTina will
// not be called. No warnings or errors will be thrown.
```

---

Update also resolves `getDocumentFromComponent` for certain React 16 versions:

https://github.com/helpscout/react-utils/issues/9