### PR TITLE
isPropValid: Add custom props to blacklist

### DIFF
--- a/src/__tests__/isPropValid.test.js
+++ b/src/__tests__/isPropValid.test.js
@@ -1,0 +1,9 @@
+import isPropValid from '../isPropValid'
+
+test('Filters out other stray props', () => {
+  const props = ['action']
+
+  props.forEach(prop => {
+    expect(isPropValid(prop)).toBeFalsy()
+  })
+})

--- a/src/isPropValid.ts
+++ b/src/isPropValid.ts
@@ -29,7 +29,7 @@ const isCustomAttribute = RegExp.prototype.test.bind(
 )
 
 /* Custom filter list */
-const OTHER_ATTRIBUTE_REGEX = /action/g
+const OTHER_ATTRIBUTE_REGEX = /^(action)/g
 
 export default (name: string): boolean => {
   return (

--- a/src/isPropValid.ts
+++ b/src/isPropValid.ts
@@ -28,5 +28,12 @@ const isCustomAttribute = RegExp.prototype.test.bind(
   new RegExp(`^(x|data|aria)-[${ATTRIBUTE_NAME_CHAR}]*$`)
 )
 
-export default (name: string) =>
-  ATTRIBUTE_REGEX.test(name) || isCustomAttribute(name.toLowerCase())
+/* Custom filter list */
+const OTHER_ATTRIBUTE_REGEX = /action/g
+
+export default (name: string): boolean => {
+  return (
+    (ATTRIBUTE_REGEX.test(name) || isCustomAttribute(name.toLowerCase())) &&
+    !OTHER_ATTRIBUTE_REGEX.test(name)
+  )
+}


### PR DESCRIPTION
## isPropValid: Add custom props to blacklist

This update adjusts the `isPropValid` function to add a custom black list,
starting with the prop `action`.

In HSDS: React development, we noticed that the prop `action` leaked through.