### PR TITLE
Upgrade peer dependencies React, React DOM and React Test Renderer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17555,15 +17555,14 @@
       }
     },
     "react": {
-      "version": "16.8.6",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.8.6.tgz",
-      "integrity": "sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==",
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.13.1.tgz",
+      "integrity": "sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==",
       "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.13.6"
+        "prop-types": "^15.6.2"
       }
     },
     "react-app-polyfill": {
@@ -17924,15 +17923,15 @@
       }
     },
     "react-dom": {
-      "version": "16.8.6",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.6.tgz",
-      "integrity": "sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==",
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.1.tgz",
+      "integrity": "sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==",
       "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
-        "scheduler": "^0.13.6"
+        "scheduler": "^0.19.1"
       }
     },
     "react-error-overlay": {
@@ -18008,15 +18007,15 @@
       }
     },
     "react-test-renderer": {
-      "version": "16.8.6",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.8.6.tgz",
-      "integrity": "sha512-H2srzU5IWYT6cZXof6AhUcx/wEyJddQ8l7cLM/F7gDXYyPr4oq+vCIxJYXVGhId1J706sqziAjuOEjyNkfgoEw==",
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.13.1.tgz",
+      "integrity": "sha512-Sn2VRyOK2YJJldOqoh8Tn/lWQ+ZiKhyZTPtaO0Q6yNj+QDbmRkVFap6pZPy3YQk8DScRDfyqm/KxKYP9gCMRiQ==",
       "dev": true,
       "requires": {
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
         "react-is": "^16.8.6",
-        "scheduler": "^0.13.6"
+        "scheduler": "^0.19.1"
       }
     },
     "react-textarea-autosize": {
@@ -19122,9 +19121,9 @@
       "dev": true
     },
     "scheduler": {
-      "version": "0.13.6",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.6.tgz",
-      "integrity": "sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
       "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -57,9 +57,9 @@
     "enzyme": "3.10.0",
     "enzyme-adapter-react-16": "1.14.0",
     "nyc": "13.3.0",
-    "react": "16.8.6",
-    "react-dom": "16.8.6",
-    "react-test-renderer": "16.8.6"
+    "react": "16.13.1",
+    "react-dom": "16.13.1",
+    "react-test-renderer": "16.13.1"
   },
   "dependencies": {
     "create-react-context": "0.2.3",

--- a/src/renderSpy.tsx
+++ b/src/renderSpy.tsx
@@ -26,7 +26,7 @@ function renderSpy(options) {
       performanceTimer: number = 0
       ownerDisplayName = ''
 
-      componentWillMount() {
+      UNSAFE_componentWillMount() {
         this.ownerDisplayName = getOwnerDisplayName(this)
         this.startTimer()
       }
@@ -37,7 +37,7 @@ function renderSpy(options) {
         console.groupEnd()
       }
 
-      componentWillUpdate() {
+      UNSAFE_componentWillUpdate() {
         this.startTimer()
       }
 
@@ -53,11 +53,11 @@ function renderSpy(options) {
           console.log(
             '%cWasted render: %cNo props were changed for this render.',
             'color: gray; font-weight: bold;',
-            'color: gray; font-weight: normal;'
+            'color: gray; font-weight: normal;',
           )
           console.log(
             `%cBelow is a collection of wasted renders we've seen so far:`,
-            'color: #bbb'
+            'color: #bbb',
           )
 
           // Add to the internal wasted render collection (:sob:)
@@ -79,12 +79,12 @@ function renderSpy(options) {
           console.log(
             '%cPrevious  ',
             'color: grey; font-weight: bold;',
-            previous
+            previous,
           )
           console.log(
             '%cChanges   ',
             'color: dodgerblue; font-weight: bold;',
-            diffs
+            diffs,
           )
           console.log('%cNext      ', 'color: green; font-weight: bold;', next)
         }
@@ -100,7 +100,7 @@ function renderSpy(options) {
         action: string,
         renderTime: any,
         collapsed: boolean,
-        extra?: any
+        extra?: any,
       ) => {
         const hasRenderTime = renderTime !== undefined && renderTime !== null
         let message = `%c${action} %c${displayName}`
@@ -150,12 +150,12 @@ function renderSpy(options) {
 
     const EnhancedComponent = hoistNonReactStatics(
       ReactRenderSpy,
-      WrappedComponent
+      WrappedComponent,
     )
 
     EnhancedComponent.displayName = wrapComponentName(
       WrappedComponent,
-      'withRenderSpy'
+      'withRenderSpy',
     )
 
     return EnhancedComponent
@@ -192,7 +192,7 @@ export function printWastedRenderCollection(renderSpyWastedRenderCollection) {
     .sort(
       /* istanbul ignore next */
       // @ts-ignore
-      (a, b) => b.wastedRenders - a.wastedRenders
+      (a, b) => b.wastedRenders - a.wastedRenders,
     )
     // Make the data pretty for printing
     .map(item => {


### PR DESCRIPTION
This is on hold until all HSDS v3 migrations have been merged in HSAPP in order to proceed with testing in HSApp

This simply updates the React, React DOM and React Test Renderer peer dependencies to 16.13.1 (latest)